### PR TITLE
drf-yasg compatiblitiy

### DIFF
--- a/comment/api/serializers.py
+++ b/comment/api/serializers.py
@@ -64,6 +64,7 @@ class UserSerializer(serializers.ModelSerializer):
         model = get_user_model()
         fields = get_user_fields()
         lookup_field = 'username'
+        ref_name = 'comment.UserSerializer'
 
     def get_profile(self, obj):
         try:
@@ -86,6 +87,7 @@ def create_comment_serializer(model_type=None,
 
         class Meta:
             model = Comment
+            ref_name = 'comment.{}'.format(model_type)
             fields = (
                 'id',
                 'user',


### PR DESCRIPTION
when using drf-yasg, below error occur.

> drf_yasg.errors.SwaggerGenerationError: Schema for <class 'comment.api.serializers.create_comment_serializer.<locals>.CommentCreateSerializer'> would override distinct serializer <class 'comment.api.serializers.create_comment_serializer.<locals>.CommentCreateSerializer'> because they implicitly share the same ref_name; explicitly set the ref_name atribute on both serializers' Meta classes